### PR TITLE
Update Rubocop version and add rubocop-rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 ---
 require:
+  - rubocop-rails
   - rubocop-performance
   - rubocop-rspec
 

--- a/fake_gem__.gemspec
+++ b/fake_gem__.gemspec
@@ -12,9 +12,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'mdl', '0.9.0'
   s.add_dependency 'rake' # needed by reek
   s.add_dependency 'reek', '6.0.3'
-  s.add_dependency 'rubocop', '1.10.0'
-  s.add_dependency 'rubocop-performance', '1.6.1'
-  s.add_dependency 'rubocop-rspec', '1.40.0'
+  s.add_dependency 'rubocop', '1.20.0'
+  s.add_dependency 'rubocop-performance', '1.11.5'
+  s.add_dependency 'rubocop-rails', '2.12.2'
+  s.add_dependency 'rubocop-rspec', '2.4.0'
   s.bindir = 'pre_commit_hooks'
   s.executables = [
     'run-bundle-audit',


### PR DESCRIPTION
- Update rubocop to version '1.20.0'
- Update rubocop-performance to version '1.11.5'
- Update rubocop-rails to version '2.12.2'
- Update rubocop-rspec to version '2.4.0'
- Require rubocop-rails in rubocop configuration file